### PR TITLE
Update prepare_locs.R to change idate format

### DIFF
--- a/R/prepare_locs.R
+++ b/R/prepare_locs.R
@@ -6,7 +6,9 @@ prepare_locs <- function(DT, id, datetime, tz, x, y, split_by) {
 
 	DT[, (datetime) := parse_date(datetime_char, default_tz = tz),
 		 env = list(datetime_char = datetime)]
-
+	# changing IDate format to a different variable to avoid iteration = "group" error later on
+	DT[, idate := as.Date(idate)]
+	
 	# Make unique and complete
 	unique_DT <- unique(DT, by = c(id, datetime))
 	na_omit_DT <- na.omit(unique_DT, cols = c(x, y, datetime))

--- a/R/prepare_locs.R
+++ b/R/prepare_locs.R
@@ -6,9 +6,11 @@ prepare_locs <- function(DT, id, datetime, tz, x, y, split_by) {
 
 	DT[, (datetime) := parse_date(datetime_char, default_tz = tz),
 		 env = list(datetime_char = datetime)]
-	# changing IDate format to a different variable to avoid iteration = "group" error later on
-	DT[, idate := as.Date(idate)]
 	
+	# Cast any IDate columns as Date
+	is_idate <- vapply(DT, function(x) 'IDate' %in% class(x), FUN.VALUE = TRUE)
+	DT[, (names(is_idate)) := lapply(.SD, as.Date), .SDcols = names(is_idate)]
+		   
 	# Make unique and complete
 	unique_DT <- unique(DT, by = c(id, datetime))
 	na_omit_DT <- na.omit(unique_DT, cols = c(x, y, datetime))


### PR DESCRIPTION
[@robitalec: Related to the {vctrs} and tar_group clashing when using `data.table::as.IDate` since {vctrs} doesn't have methods for IDates]